### PR TITLE
 I think the option should have methods like unwrap_or.

### DIFF
--- a/spec/option_spec.cr
+++ b/spec/option_spec.cr
@@ -145,6 +145,11 @@ describe Option do
     o = None(Int32).new << Option.of(1)
     o.class.should eq None(Int32)
   end
+
+  it "unwrap_or" do
+    Option.of(1).unwrap_or_else(0).should eq 1
+    Option::None(Int32).new.unwrap_or_else(0).should eq 0
+  end
 end
 
 def sum(*args)

--- a/src/crz/option.cr
+++ b/src/crz/option.cr
@@ -26,11 +26,30 @@ module CRZ::Containers
         }
       end
 
+      def get : A
+        unwrap
+      end
+
+      def unwrap_or_else(default : A) : A
+        Option.match self, Option(A), {
+            [Some, x] => x,
+            [None]    => default
+        }
+      end
+
+      def get_or_else(default : A) : A
+        unwrap_or_else(default)
+      end
+
       def has_value : Bool
         Option.match self, Option(A), {
           [Some, _] => true,
           [_]       => false,
         }
+      end
+
+      def flat_map(&block : A -> Option(B)) : Option(B) forall B
+        bind(block)
       end
 
       def bind(&block : A -> Option(B)) : Option(B) forall B


### PR DESCRIPTION
I think the option should have methods like unwrap_or.

```
p mdo({
  x <= Some.new(1),
  y <= None(Int32).new,
  Some.new(x + y)
}).get_or_else(0)
```
Thanks and regards!