### PR TITLE
Fix shard install reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Breaking changes:
 Add this to your shard.yml
 ```yaml
 crz:
-  git: dhruvrajvanshi/crz
+  github: dhruvrajvanshi/crz
   version: ~> 1.0.0
 ```
 


### PR DESCRIPTION
Shards declaration needs to be `github` instead of `git` or the shorthand format fails.

Thanks for the library :).